### PR TITLE
[DEV] Hotfix #6 Removed conditional check for the second gitversion step

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -57,7 +57,6 @@ jobs:
 
     # Step 5: Run GitVersion to determine version (updated after tagging if first got version with main from Step 4)
     - name: Determine version with GitVersion
-      if: github.ref == 'refs/heads/main'
       uses: gittools/actions/gitversion/execute@v3.0.3
       id: gitversion
 


### PR DESCRIPTION
`if: github.ref == 'refs/heads/main'` was accidentally left over and caused release workflow to fail.