### PR TITLE
[DEV] feature #9 added integration tests with Testcontainers

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,12 +60,13 @@ jobs:
       uses: gittools/actions/gitversion/execute@v3.0.3
       id: gitversion
 
-    # Step 6: Set version and build the project using shadowJar
+    # Step 6: Set version, run unit tests, build the project using shadowJar,
+    #   and run integration tests (fails the pipeline if Docker is not available or tests fail)
     - name: Display Version
       run: echo "Version ${{ steps.gitversion.outputs.semVer }}"
 
-    - name: Build shadowJar with version
-      run: gradle shadowJar -PbuildVersion='${{ steps.gitversion.outputs.semVer }}'
+    - name: Verify build and run all tests
+      run: gradle verify -PbuildVersion='${{ steps.gitversion.outputs.semVer }}'
 
     # Step 7: Tag the commit with the version
     - name: Tag the commit with version
@@ -91,7 +92,7 @@ jobs:
         draft: true
         prerelease: ${{ github.ref != 'refs/heads/main' }}
 
-    # Step 10: Upload shadowJar .jar to release
+    # Step 9: Upload shadowJar .jar to release
     - name: Upload shadowJar to release
       uses: actions/upload-release-asset@v1
       env:

--- a/README.md
+++ b/README.md
@@ -41,7 +41,11 @@ extensions/ksql-udaf-statistics-<version>.jar
 Mount the generated JAR as an extension in ksqlDB:
 
 ```bash
-docker run -it --rm   -v $(pwd)/extensions:/opt/ksqldb-udfs   -e KSQL_KSQL_EXTENSION_DIR=/opt/ksqldb-udfs   -p 8088:8088   confluentinc/ksqldb-server:0.29.0
+docker run -it --rm \
+  -v /path/to/your/repo/extensions:/opt/ksqldb-udfs \
+  -e KSQL_KSQL_EXTENSION_DIR=/opt/ksqldb-udfs \
+  -p 8088:8088 \
+  confluentinc/ksqldb-server:0.29.0
 ```
 
 ### 3. Use in ksqlDB

--- a/README.md
+++ b/README.md
@@ -1,2 +1,138 @@
 # ksql-udaf-statistics
-A collection of user-defined aggregate functions (UDAFs) for ksqlDB that perform additional basic and advanced statistical calculations on aggregated data
+
+A collection of custom **ksqlDB User-Defined Aggregate Functions (UDAFs)** that perform additional basic and advanced statistical calculations on aggregated data.
+
+## Features
+
+- Implements `STDDEV_WEIGHTED` and `SKEWNESS_WEIGHTED` UDAFs.
+- Supports weighted aggregation on streaming values using ksqlDB.
+- Designed to work with `ksqldb-server` via UDF extensions.
+- Includes unit tests and integration tests using Testcontainers.
+- Compatible with ksqlDB 0.29.0 and Kafka 7.8.0.
+
+## Use Cases
+
+- Calculate real-time statistical metrics (beyond those available in ksqlDB) over event streams (e.g., financial data, telemetry).
+
+## Quickstart
+
+### 1. Install Gradle
+This project was built using Gradle 8.11.1. Please ensure that Gradle is installed on your system before proceeding.
+You can verify your installation with:
+```bash
+gradle --version
+```
+> **Note:** This project does not include a Gradle wrapper (```gradlew```). You must install Gradle manually.
+
+### 1. Build the UDAF Extension JAR
+
+```
+gradle shadowJar
+```
+
+This builds the uber-JAR including all required dependencies and places it at:
+
+```
+extensions/ksql-udaf-statistics-<version>.jar
+```
+
+### 2. Run With ksqlDB
+
+Mount the generated JAR as an extension in ksqlDB:
+
+```bash
+docker run -it --rm   -v $(pwd)/extensions:/opt/ksqldb-udfs   -e KSQL_KSQL_EXTENSION_DIR=/opt/ksqldb-udfs   -p 8088:8088   confluentinc/ksqldb-server:0.29.0
+```
+
+### 3. Use in ksqlDB
+
+```sql
+-- Create a stream
+CREATE STREAM input (val DOUBLE, weight DOUBLE)
+  WITH (KAFKA_TOPIC='input', VALUE_FORMAT='json');
+
+-- Aggregate using the UDAF
+CREATE TABLE agg_result WITH (
+  KAFKA_TOPIC='output',
+  KEY_FORMAT='JSON'
+) AS
+SELECT
+  'singleton' AS id,
+   STDDEV_WEIGHTED(val, weight) AS stddev,
+   SKEWNESS_WEIGHTED(val, weight) AS skewness
+FROM input
+GROUP BY 'singleton';
+```
+You can also apply these UDAFs in a window (e.g. tumbling) to compute aggregates over time periods:
+```sql
+-- Time-windowed aggregation example
+CREATE TABLE agg_result_windowed WITH (
+  KAFKA_TOPIC = 'output',
+  KEY_FORMAT = 'JSON'
+) AS
+SELECT
+  'singleton' AS id,
+  WINDOWSTART AS window_start,
+  STDDEV_WEIGHTED(val, weight) AS stddev,
+  SKEWNESS_WEIGHTED(val, weight) AS skewness
+FROM input
+WINDOW TUMBLING (SIZE 5 MINUTES)
+GROUP BY 'singleton';
+```
+> **Note:** ```'singleton'``` is used as a constant key to satisfy the ```GROUP BY``` requirement for tables in ksqlDB. You can replace it with an actual column name if grouping by real data fields.
+
+## Development
+
+This project uses:
+
+- Java 11
+- Gradle with Shadow Plugin
+- Confluent's ksqlDB UDF API (`ksqldb-udf`, `ksqldb-common`)
+- Apache Kafka (`kafka_2.13`)
+- Testcontainers for integration testing
+
+### Run All Tests and Build Uber-JAR
+```
+gradle verify
+```
+
+### Run Unit Tests
+```
+gradle test
+```
+
+### Build Uber-JAR
+This includes all required dependencies for ksqlDB server.
+```
+gradle shadowJar
+```
+
+### Run Only Integration Tests
+This will use Testcontainers to spin up Kafka and ksqlDB server w/ mounted UDF extension to test functions end-to-end.
+```
+gradle integrationTest
+```
+
+> **Note:** Docker must be running for integration tests.
+
+> **Note:** The latest uber-JAR must be built using ```shadowJar``` before running integration tests.
+
+## Project Structure
+
+- `WeightedStdDevUdaf`: UDAF for weighted standard deviation.
+- `WeightedSkewnessUdaf`: UDAF for weighted skewness.
+- `AllUdafIT`: Integration test validating UDAF behavior with real ksqlDB and Kafka.
+- `WeightedStdDevUdafTest` / `WeightedSkewnessUdafTest`: Unit tests for aggregation logic.
+- `UdafMetadata`: Utility to extract registered UDAF function names via annotations.
+
+## Publishing
+
+Release artifacts are automatically created by the GitHub Actions pipeline:
+- A release JAR is built using Gradle (```shadowJar```) and placed in ```extensions/```.
+- The pipeline uploads this JAR to a **GitHub Release**, tagged with the current version.
+- Draft releases are created as stable for the main branch, and as prerelease for other branches.
+- Detailed release description (following the format of previous releases) must be added manually before publishing.
+
+## License
+
+MIT License. See [LICENSE](./LICENSE) for details.

--- a/build.gradle
+++ b/build.gradle
@@ -14,6 +14,7 @@ repositories {
 }
 
 dependencies {
+    // Core ksqlDB UDAF and Kafka dependencies
     implementation "io.confluent.ksql:ksqldb-udf:7.3.1"
     implementation "io.confluent.ksql:ksqldb-common:7.3.1"
     implementation "org.apache.kafka:kafka_2.13:3.3.1"
@@ -26,6 +27,11 @@ dependencies {
 
     // Mockito for mocking dependencies in tests
     testImplementation "org.mockito:mockito-core:5.14.0"
+    
+    // Testcontainers for integration testing (core, kafka-specific and JUnit Jupiter integration)
+    testImplementation "org.testcontainers:testcontainers:1.19.1"
+    testImplementation "org.testcontainers:kafka:1.19.1"
+    testImplementation "org.testcontainers:junit-jupiter:1.19.1"
 }
 
 java {
@@ -47,4 +53,25 @@ compileJava {
 test {
     // Enables JUnit 5 testing
     useJUnitPlatform()
+    exclude '**/*IT.class' // Don't run integration tests here
+}
+
+tasks.named('shadowJar') {
+    mustRunAfter check
+}
+
+task integrationTest(type: Test) {
+    description = "Runs integration tests"
+    group = "verification"
+    testClassesDirs = sourceSets.test.output.classesDirs
+    classpath = sourceSets.test.runtimeClasspath
+    include '**/*IT.class' // Only run files like AllUdaIT
+    mustRunAfter shadowJar
+    useJUnitPlatform()
+}
+
+task verify {
+    group = "verification"
+    description = "Runs unit tests, builds the uber-JAR, and then runs integration tests"
+    dependsOn 'check', 'shadowJar', 'integrationTest'
 }

--- a/build.gradle
+++ b/build.gradle
@@ -15,10 +15,9 @@ repositories {
 
 dependencies {
     // Core ksqlDB UDAF and Kafka dependencies
-    implementation "io.confluent.ksql:ksqldb-udf:7.3.1"
+    compileOnly "io.confluent.ksql:ksqldb-udf:7.3.1"
     implementation "io.confluent.ksql:ksqldb-common:7.3.1"
-    implementation "org.apache.kafka:kafka_2.13:3.3.1"
-    implementation "org.apache.kafka:connect-api:3.3.1"
+    compileOnly "org.apache.kafka:kafka_2.13:3.3.1"
 
     // JUnit 5 (Jupiter) for unit testing
     testImplementation "org.junit.jupiter:junit-jupiter-api:5.9.2"

--- a/build.gradle
+++ b/build.gradle
@@ -54,6 +54,11 @@ test {
     // Enables JUnit 5 testing
     useJUnitPlatform()
     exclude '**/*IT.class' // Don't run integration tests here
+
+    testLogging {
+        showStandardStreams = true
+        events "passed", "skipped", "failed", "standard_out", "standard_error"
+    }
 }
 
 tasks.named('shadowJar') {
@@ -68,6 +73,11 @@ task integrationTest(type: Test) {
     include '**/*IT.class' // Only run files like AllUdaIT
     mustRunAfter shadowJar
     useJUnitPlatform()
+
+    testLogging {
+        showStandardStreams = true
+        events "passed", "skipped", "failed", "standard_out", "standard_error"
+    }
 }
 
 task verify {

--- a/build.gradle
+++ b/build.gradle
@@ -32,6 +32,9 @@ dependencies {
     testImplementation "org.testcontainers:testcontainers:1.19.1"
     testImplementation "org.testcontainers:kafka:1.19.1"
     testImplementation "org.testcontainers:junit-jupiter:1.19.1"
+    
+    // Reflection for integration testing to get UDAF names from class annotations
+    testImplementation "org.reflections:reflections:0.10.2"
 }
 
 java {

--- a/src/main/java/com/kcharkseliani/kafka/ksql/statistics/WeightedSkewnessUdaf.java
+++ b/src/main/java/com/kcharkseliani/kafka/ksql/statistics/WeightedSkewnessUdaf.java
@@ -96,6 +96,11 @@ public class WeightedSkewnessUdaf {
             // Calculating the weighted skewness
             double skewness = (sumWeightCubes / sumWeights) - 3 * mean * (sumWeightSquares / sumWeights) + 2*Math.pow(mean, 3);
 
+            // if variance is 0, avoid division by zero
+            if (variance == 0.0) {
+                return 0.0;
+            }
+
             // Returning the weighted skewness
             return skewness / Math.pow(Math.max(variance, 0.0), 1.5);  // Normalize by the variance's 3/2 power
         }

--- a/src/main/java/com/kcharkseliani/kafka/ksql/statistics/WeightedSkewnessUdaf.java
+++ b/src/main/java/com/kcharkseliani/kafka/ksql/statistics/WeightedSkewnessUdaf.java
@@ -8,18 +8,36 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 
+/**
+ * A user-defined aggregate function (UDAF) for computing weighted skewness in ksqlDB.
+ * 
+ * This UDAF accepts pairs of (value, weight) and maintains a running calculation of
+ * weighted sums, squares, and cubes to compute skewness on streaming data.
+ * 
+ * Registered under the function name {@code skewness_weighted}.
+ * 
+ * This class is stateless and delegates all UDAF logic to its internal 
+ * {@link WeightedSkewnessUdafImpl} implementation class.
+ */
 @UdafDescription(name = "skewness_weighted",
                  author = "Konstantin Charkseliani",
                  version = "0.1.0",
                  description = "Calculates skewness based on weights of each value")
-
 public class WeightedSkewnessUdaf {
 
+    /** Field name for the internal aggregation state of the sum of values. */
     private static final String SUM_VALUES = "SUM_VALUES";
+
+    /** Field name for the internal aggregation state of the sum of weights. */
     private static final String SUM_WEIGHTS = "SUM_WEIGHTS";
+
+    /** Field name for the internal aggregation state of the sum of weighted squares. */
     private static final String SUM_WEIGHT_SQUARES = "SUM_WEIGHT_SQUARES";
+
+    /** Field name for the internal aggregation state of the sum of weighted cubes. */
     private static final String SUM_WEIGHT_CUBES = "SUM_WEIGHT_CUBES";
 
+    /** Schema used to structure the aggregation result. */
     private static final Schema STRUCT_SCHEMA = SchemaBuilder.struct().optional()
         .field(SUM_VALUES, Schema.OPTIONAL_FLOAT64_SCHEMA)
         .field(SUM_WEIGHTS, Schema.OPTIONAL_FLOAT64_SCHEMA)
@@ -27,18 +45,35 @@ public class WeightedSkewnessUdaf {
         .field(SUM_WEIGHT_CUBES, Schema.OPTIONAL_FLOAT64_SCHEMA)
         .build();
 
+    /** Private constructor to prevent instantiation. */
     private WeightedSkewnessUdaf() {
     }
 
+    /**
+     * Factory method to register the weighted skewness UDAF with ksqlDB.
+     *
+     * @return a new instance of the UDAF implementation
+     */
     @UdafFactory(description = "Calculates the weighted skewness of a stream of values with weights.",
             aggregateSchema = "STRUCT<SUM_VALUES double, SUM_WEIGHTS double, SUM_WEIGHT_SQUARES double, SUM_WEIGHT_CUBES double>")
     public static Udaf<Pair<Double, Double>, Struct, Double> createUdaf() {
         return new WeightedSkewnessUdafImpl();
     }
 
+    /**
+     * Implementation of the weighted skewness UDAF logic.
+     * 
+     * Aggregates a stream of (value, weight) pairs into a struct and calculates
+     * weighted skewness during mapping or merges two aggregations.
+     */
     private static class WeightedSkewnessUdafImpl
             implements Udaf<Pair<Double, Double>, Struct, Double> {
 
+        /**
+         * Initializes the aggregation state with zeroed values.
+         *
+         * @return an empty {@link Struct} for tracking aggregation
+         */
         @Override
         public Struct initialize() {
             return new Struct(STRUCT_SCHEMA)
@@ -48,6 +83,13 @@ public class WeightedSkewnessUdaf {
                 .put(SUM_WEIGHT_CUBES, 0.0);
         }
 
+        /**
+         * Aggregates a new (value, weight) pair into the current aggregation state.
+         *
+         * @param newValue the pair of input value and weight
+         * @param aggregateValue the current aggregation state
+         * @return a new {@link Struct} with updated sums
+         */
         @Override
         public Struct aggregate(Pair<Double, Double> newValue, Struct aggregateValue) {
             // Extracting values from the Pair and the current state of the accumulator (Struct)
@@ -74,6 +116,12 @@ public class WeightedSkewnessUdaf {
                 .put(SUM_WEIGHT_CUBES, sumWeightCubes);
         }
 
+        /**
+         * Computes the final weighted skewness from the aggregated values.
+         *
+         * @param aggregate the aggregation struct
+         * @return the weighted skewness, or 0.0 if weights or variance is zero
+         */
         @Override
         public Double map(Struct aggregate) {
             // If no data was aggregated, return 0.0 as the skewness
@@ -105,6 +153,13 @@ public class WeightedSkewnessUdaf {
             return skewness / Math.pow(Math.max(variance, 0.0), 1.5);  // Normalize by the variance's 3/2 power
         }
 
+        /**
+         * Merges two intermediate aggregation structs.
+         *
+         * @param aggOne the first aggregation state
+         * @param aggTwo the second aggregation state
+         * @return a new merged {@link Struct}
+         */
         @Override
         public Struct merge(Struct aggOne, Struct aggTwo) {
             // Merging two accumulators by summing their respective values

--- a/src/main/java/com/kcharkseliani/kafka/ksql/statistics/WeightedStdDevUdaf.java
+++ b/src/main/java/com/kcharkseliani/kafka/ksql/statistics/WeightedStdDevUdaf.java
@@ -8,35 +8,68 @@ import org.apache.kafka.connect.data.Schema;
 import org.apache.kafka.connect.data.SchemaBuilder;
 import org.apache.kafka.connect.data.Struct;
 
+/**
+ * A user-defined aggregate function (UDAF) for computing weighted standard deviation in ksqlDB.
+ * 
+ * This UDAF processes pairs of (value, weight) and maintains running sums required to compute
+ * the standard deviation in a weighted manner.
+ * 
+ * Registered under the function name {@code stddev_weighted}.
+ * 
+ * This class is stateless and delegates all UDAF logic to its internal 
+ * {@link WeightedStdDevUdafImpl} implementation class.
+ */
 @UdafDescription(name = "stddev_weighted",
                  author = "Konstantin Charkseliani",
                  version = "0.1.0",
                  description = "Calculates standard deviation based on weights of each value")
-
 public class WeightedStdDevUdaf {
 
+    /** Field name for the internal aggregation state of the sum of values. */
     private static final String SUM_VALUES = "SUM_VALUES";
+
+    /** Field name for the internal aggregation state of the sum of weights. */
     private static final String SUM_WEIGHTS = "SUM_WEIGHTS";
+
+    /** Field name for the internal aggregation state of the sum of weighted squares. */
     private static final String SUM_WEIGHT_SQUARES = "SUM_WEIGHT_SQUARES";
 
+    /** Schema used to structure the aggregation result. */
     private static final Schema STRUCT_SCHEMA = SchemaBuilder.struct().optional()
         .field(SUM_VALUES, Schema.OPTIONAL_FLOAT64_SCHEMA)
         .field(SUM_WEIGHTS, Schema.OPTIONAL_FLOAT64_SCHEMA)
         .field(SUM_WEIGHT_SQUARES, Schema.OPTIONAL_FLOAT64_SCHEMA)
         .build();
 
+    /** Private constructor to prevent instantiation. */
     private WeightedStdDevUdaf() {
     }
 
+    /**
+     * Factory method to register the weighted standard deviation UDAF with ksqlDB.
+     *
+     * @return a new instance of the UDAF implementation
+     */
     @UdafFactory(description = "Calculates the weighted standard deviation of a stream of values with weights.",
             aggregateSchema = "STRUCT<SUM_VALUES double, SUM_WEIGHTS double, SUM_WEIGHT_SQUARES double>")
     public static Udaf<Pair<Double, Double>, Struct, Double> createUdaf() {
         return new WeightedStdDevUdafImpl();
     }
 
+    /**
+     * Implementation of the weighted standard deviation UDAF logic.
+     * 
+     * Aggregates a stream of (value, weight) pairs into a struct and calculates
+     * the final result in the {@code map} method. Also supports merging of partial results.
+     */
     private static class WeightedStdDevUdafImpl
             implements Udaf<Pair<Double, Double>, Struct, Double> {
 
+        /**
+         * Initializes the aggregation state with zeroed values.
+         *
+         * @return an empty {@link Struct} for tracking aggregation
+         */
         @Override
         public Struct initialize() {
             return new Struct(STRUCT_SCHEMA)
@@ -45,6 +78,13 @@ public class WeightedStdDevUdaf {
                 .put(SUM_WEIGHT_SQUARES, 0.0);
         }
 
+        /**
+         * Aggregates a new (value, weight) pair into the current aggregation state.
+         *
+         * @param newValue the pair of input value and weight
+         * @param aggregateValue the current aggregation state
+         * @return a new {@link Struct} with updated sums
+         */
         @Override
         public Struct aggregate(Pair<Double, Double> newValue, Struct aggregateValue) {
             // Extracting values from the Pair and the current state of the accumulator (Struct)
@@ -68,6 +108,12 @@ public class WeightedStdDevUdaf {
                 .put(SUM_WEIGHT_SQUARES, sumWeightSquares);
         }
 
+        /**
+         * Computes the final weighted standard deviation from the aggregated values.
+         *
+         * @param aggregate the aggregation struct
+         * @return the weighted standard deviation, or 0.0 if weights are zero
+         */
         @Override
         public Double map(Struct aggregate) {
             // If no data was aggregated, return 0.0 as the standard deviation
@@ -90,6 +136,13 @@ public class WeightedStdDevUdaf {
             return Math.sqrt(Math.max(variance, 0.0)); // Ensure non-negative variance
         }
 
+        /**
+         * Merges two intermediate aggregation structs.
+         *
+         * @param aggOne the first aggregation state
+         * @param aggTwo the second aggregation state
+         * @return a new merged {@link Struct}
+         */
         @Override
         public Struct merge(Struct aggOne, Struct aggTwo) {
             // Merging two accumulators by summing their respective values

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
@@ -1,0 +1,25 @@
+package com.kcharkseliani.kafka.ksql.statistics;
+
+import org.junit.jupiter.api.*;
+import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.GenericContainer;
+import org.testcontainers.utility.DockerImageName;
+
+public class AllUdafIT {
+
+    @BeforeAll
+    static void startContainers() {
+        throw new UnsupportedOperationException("Method startContainers not implemented");
+    }
+
+    @Test
+    void testKsqlWithCustomUdaf() throws Exception {
+        throw new UnsupportedOperationException("Method testKsqlWithCustomUdaf not implemented");
+    }
+
+    @AfterAll
+    static void stopContainers() {
+        throw new UnsupportedOperationException("Method stopContainers not implemented");
+    }
+
+}

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
@@ -107,7 +107,7 @@ public class AllUdafIT {
      */
     @Test
     @Order(1)
-    void testDeployment_shouldContainAllDeclaredUdafs() throws Exception {
+    void testDeployment_ShouldContainAllDeclaredUdafs() throws Exception {
 
         Set<String> expectedFunctionNames = UdafMetadata.getDeclaredUdafNames();
         System.out.println("Expected UDAF names from annotations: " + expectedFunctionNames);

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
@@ -141,8 +141,8 @@ public class AllUdafIT {
     }
 
     /**
-     * Tests the STDDEV_WEIGHTED UDAF on a set of weighted values and compares the result to the expected 
-     * standard deviation.
+     * Tests the STDDEV_WEIGHTED UDAF on a set of weighted values.
+     * Asserts that the standard deviation value matches the expected computation.
      *
      * @throws Exception if any ksqlDB or HTTP operation fails
      */
@@ -159,7 +159,7 @@ public class AllUdafIT {
 
     /**
      * Tests the STDDEV_WEIGHTED UDAF on all-zero values and weights.
-     * Verifies the result is zero and does not produce NaN or error.
+     * Asserts that the result is zero and does not produce NaN or error.
      *
      * @throws Exception if the test setup or query fails
      */
@@ -193,7 +193,7 @@ public class AllUdafIT {
 
     /**
      * Tests the SKEWNESS_WEIGHTED UDAF where all weights are zero.
-     * Expects the result to be zero without causing division errors.
+     * Asserts that the result is zero and does not produce NaN or error.
      *
      * @throws Exception if setup or validation fails
      */
@@ -210,7 +210,7 @@ public class AllUdafIT {
 
     /**
      * Tests the SKEWNESS_WEIGHTED UDAF on values with zero variance.
-     * Ensures the function returns zero instead of NaN or infinity.
+     * Asserts that the result is zero and does not produce NaN or error.
      *
      * @throws Exception if ksqlDB interaction fails
      */

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
@@ -136,6 +136,17 @@ public class AllUdafIT {
         runWeightedAggregationTest(values, weights, expected, "SKEWNESS_WEIGHTED");
     }
 
+    @Test
+    void testSkewnessWeighted_AllZeroRecordsInserted_ShouldReturnZero() throws Exception {
+
+        double[] values = {0, 0, 0};
+        double[] weights = {0, 0, 0};
+
+        double expected = computeWeightedSkewness(values, weights);
+
+        runWeightedAggregationTest(values, weights, expected, "SKEWNESS_WEIGHTED");
+    }
+
     @AfterEach
     void cleanUpKsqlDbObjects() throws Exception {
         String host = ksqldb.getHost();

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
@@ -24,6 +24,8 @@ import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.StringDeserializer;
 
 import org.junit.jupiter.api.*;
+import org.junit.jupiter.api.MethodOrderer.OrderAnnotation;
+import org.junit.jupiter.api.TestMethodOrder;
 
 import org.testcontainers.containers.KafkaContainer;
 import org.testcontainers.DockerClientFactory;
@@ -40,6 +42,7 @@ import org.testcontainers.containers.Network;
  * loads UDAF extensions, inserts test records, and verifies
  * correct aggregation results using both HTTP queries and Kafka consumers.
  */
+@TestMethodOrder(OrderAnnotation.class)
 public class AllUdafIT {
 
     /**
@@ -98,11 +101,12 @@ public class AllUdafIT {
 
     /**
      * Verifies that all UDAFs defined in the codebase are correctly registered and discoverable in ksqlDB.
-     * Uses annotation scanning via {@link UdafMetadata}.
+     * Uses annotation scanning via {@link UdafMetadata}. Always runs first using {@link OrderAnnotation}
      *
      * @throws Exception if the HTTP query or parsing fails
      */
     @Test
+    @Order(1)
     void testDeployment_shouldContainAllDeclaredUdafs() throws Exception {
 
         Set<String> expectedFunctionNames = UdafMetadata.getDeclaredUdafNames();

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
@@ -170,11 +170,17 @@ public class AllUdafIT {
         // === 3. Insert test data ===
         // Sleep to wait for table creation to complete
         Thread.sleep(2_000);
-        String insertData =
-            "{\n" +
-            "  \"ksql\": \"INSERT INTO weighted_input (val, weight) VALUES (5.0, 2.0); " +
-            "INSERT INTO weighted_input (val, weight) VALUES (2.0, 4.0); " +
-            "INSERT INTO weighted_input (val, weight) VALUES (8.0, 1.0);\",\n" +
+        
+        // Build INSERT statements dynamically
+        StringBuilder insertStatements = new StringBuilder();
+        for (int i = 0; i < values.length; i++) {
+            insertStatements.append("INSERT INTO weighted_input (val, weight) VALUES (")
+                            .append(values[i]).append(", ").append(weights[i]).append("); ");
+        }
+
+        // Build the final JSON string
+        String insertData = "{\n" +
+            "  \"ksql\": \"" + insertStatements.toString().trim() + "\",\n" +
             "  \"streamsProperties\": {}\n" +
             "}";
 

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
@@ -147,6 +147,17 @@ public class AllUdafIT {
         runWeightedAggregationTest(values, weights, expected, "SKEWNESS_WEIGHTED");
     }
 
+    @Test
+    void testSkewnessWeighted_ZeroVarianceRecordsInserted_ShouldReturnZero() throws Exception {
+
+        double[] values = {0, 0, 0};
+        double[] weights = {1, 1, 1};
+
+        double expected = computeWeightedSkewness(values, weights);
+
+        runWeightedAggregationTest(values, weights, expected, "SKEWNESS_WEIGHTED");
+    }
+
     @AfterEach
     void cleanUpKsqlDbObjects() throws Exception {
         String host = ksqldb.getHost();

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
@@ -2,14 +2,37 @@ package com.kcharkseliani.kafka.ksql.statistics;
 
 import org.junit.jupiter.api.*;
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
+import org.testcontainers.containers.Network;
 
 public class AllUdafIT {
 
+    static KafkaContainer kafka;
+    static GenericContainer<?> ksqldb;
+
+    static Network network = Network.newNetwork();
+
     @BeforeAll
     static void startContainers() {
-        throw new UnsupportedOperationException("Method startContainers not implemented");
+        kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.8.0"))
+        .withNetwork(network)
+        .withNetworkAliases("kafka")
+        .withEnv("KAFKA_ADVERTISED_LISTENERS", "PLAINTEXT://kafka:9092")
+        .withEnv("KAFKA_LISTENERS", "PLAINTEXT://0.0.0.0:9092");
+
+        kafka.start();
+
+        ksqldb = new GenericContainer<>(DockerImageName.parse("confluentinc/ksqldb-server:0.29.0"))
+            .withNetwork(network)
+            .withExposedPorts(8088)
+            .withEnv("KSQL_BOOTSTRAP_SERVERS", "PLAINTEXT://kafka:9092")
+            .withEnv("KSQL_KSQL_EXTENSION_DIR", "/opt/ksqldb-udfs")  // mount your UDAF JAR here
+            .withFileSystemBind("extensions", "/opt/ksqldb-udfs", BindMode.READ_ONLY) // mounts your UDAF uber-jar
+            .dependsOn(kafka);
+
+        ksqldb.start();
     }
 
     @Test
@@ -19,7 +42,7 @@ public class AllUdafIT {
 
     @AfterAll
     static void stopContainers() {
-        throw new UnsupportedOperationException("Method stopContainers not implemented");
+        ksqldb.stop();
+        kafka.stop();
     }
-
 }

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
@@ -2,6 +2,7 @@ package com.kcharkseliani.kafka.ksql.statistics;
 
 import org.junit.jupiter.api.*;
 import org.testcontainers.containers.KafkaContainer;
+import org.testcontainers.DockerClientFactory;
 import org.testcontainers.containers.BindMode;
 import org.testcontainers.containers.GenericContainer;
 import org.testcontainers.utility.DockerImageName;
@@ -12,10 +13,20 @@ public class AllUdafIT {
     static KafkaContainer kafka;
     static GenericContainer<?> ksqldb;
 
-    static Network network = Network.newNetwork();
+    static Network network;
 
     @BeforeAll
-    static void startContainers() {
+    static void setUp() {
+
+        boolean dockerAvailable = DockerClientFactory.instance().isDockerAvailable();
+        System.out.println("Testcontainers Docker available: " + dockerAvailable);
+
+        if (!dockerAvailable) {
+            throw new IllegalStateException("Docker is not available. Integration tests require Docker.");
+        }
+
+        network = Network.newNetwork();
+        
         kafka = new KafkaContainer(DockerImageName.parse("confluentinc/cp-kafka:7.8.0"))
         .withNetwork(network)
         .withNetworkAliases("kafka")
@@ -41,7 +52,7 @@ public class AllUdafIT {
     }
 
     @AfterAll
-    static void stopContainers() {
+    static void tearDown() {
         ksqldb.stop();
         kafka.stop();
     }

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/WeightedSkewnessUdafTest.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/WeightedSkewnessUdafTest.java
@@ -147,5 +147,30 @@ public class WeightedSkewnessUdafTest {
 
         assertEquals(0.0, skewness, 0.0001);
     }
+
+    /**
+     * Tests that {@code map} returns 0 when variance is zero,
+     * even if weights are non-zero (e.g. all values are the same).
+     */
+    @Test
+    void testMapWithZeroVariance() {
+        // All values are 3.0, weights are non-zero, so variance = 0
+        double repeatedValue = 3.0;
+        double totalWeight = 6.0;
+        double sumValues = repeatedValue * totalWeight;
+        double sumWeightSquares = repeatedValue * repeatedValue * totalWeight;
+        double sumWeightCubes = repeatedValue * repeatedValue * repeatedValue * totalWeight;
+
+        Struct aggregate = new Struct(STRUCT_SCHEMA)
+                .put(SUM_VALUES, sumValues)
+                .put(SUM_WEIGHTS, totalWeight)
+                .put(SUM_WEIGHT_SQUARES, sumWeightSquares)
+                .put(SUM_WEIGHT_CUBES, sumWeightCubes);
+
+        Double skewness = udafImpl.map(aggregate);
+
+        // Expect skewness to be zero since variance is zero (all values equal)
+        assertEquals(0.0, skewness, 0.0001);
+    }
 }
 

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/WeightedSkewnessUdafTest.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/WeightedSkewnessUdafTest.java
@@ -22,7 +22,7 @@ public class WeightedSkewnessUdafTest {
     /** Instance of the UDAF under test. */
     private Udaf<Pair<Double, Double>, Struct, Double> udafImpl;
 
-    /** Field name for the internal aggregation state of the weighted values. */
+    /** Field name for the internal aggregation state of the sum of values. */
     private static final String SUM_VALUES = "SUM_VALUES";
 
     /** Field name for the internal aggregation state of the sum of weights. */

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/WeightedSkewnessUdafTest.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/WeightedSkewnessUdafTest.java
@@ -10,13 +10,31 @@ import org.junit.jupiter.api.Test;
 
 import static org.junit.jupiter.api.Assertions.*;
 
+/**
+ * Unit tests for the {@link WeightedSkewnessUdaf} class.
+ * 
+ * This class validates that the custom weighted skewness UDAF (user-defined aggregate function)
+ * behaves correctly across all of its expected operations: initialization, aggregation, mapping,
+ * and merging of intermediate states. It also verifies correct behavior when handling zero weights.
+ */
 public class WeightedSkewnessUdafTest {
 
+    /** Instance of the UDAF under test. */
     private Udaf<Pair<Double, Double>, Struct, Double> udafImpl;
+
+    /** Field name for the internal aggregation state of the weighted values. */
     private static final String SUM_VALUES = "SUM_VALUES";
+
+    /** Field name for the internal aggregation state of the sum of weights. */
     private static final String SUM_WEIGHTS = "SUM_WEIGHTS";
+
+    /** Field name for the internal aggregation state of the sum of weighted squares. */
     private static final String SUM_WEIGHT_SQUARES = "SUM_WEIGHT_SQUARES";
+
+    /** Field name for the internal aggregation state of the sum of weighted cubes. */
     private static final String SUM_WEIGHT_CUBES = "SUM_WEIGHT_CUBES";
+
+    /** Schema used to structure the aggregation result. */
     private static final Schema STRUCT_SCHEMA = SchemaBuilder.struct().optional()
             .field(SUM_VALUES, Schema.OPTIONAL_FLOAT64_SCHEMA)
             .field(SUM_WEIGHTS, Schema.OPTIONAL_FLOAT64_SCHEMA)
@@ -24,11 +42,17 @@ public class WeightedSkewnessUdafTest {
             .field(SUM_WEIGHT_CUBES, Schema.OPTIONAL_FLOAT64_SCHEMA)
             .build();
 
+    /**
+     * Initializes a new instance of the UDAF before each test.
+     */
     @BeforeEach
     void setUp() {
         udafImpl = WeightedSkewnessUdaf.createUdaf();
     }
 
+    /**
+     * Tests that the {@code initialize} method creates a struct with all zero fields.
+     */
     @Test
     void testInitialize() {
         Struct initialStruct = udafImpl.initialize();
@@ -40,6 +64,9 @@ public class WeightedSkewnessUdafTest {
         assertEquals(0.0, initialStruct.getFloat64(SUM_WEIGHT_CUBES));
     }
 
+    /**
+     * Tests that the {@code aggregate} method correctly updates the intermediate aggregation state.
+     */
     @Test
     void testAggregate() {
         Pair<Double, Double> pair = new Pair<>(5.0, 2.0);
@@ -58,6 +85,9 @@ public class WeightedSkewnessUdafTest {
         assertEquals(250.0 + 2.0 * Math.pow(5.0, 3), result.getFloat64(SUM_WEIGHT_CUBES), 0.0001);
     }
 
+    /**
+     * Tests that the {@code map} method correctly computes the weighted skewness.
+     */
     @Test
     void testMap() {
         Struct aggregate = new Struct(STRUCT_SCHEMA)
@@ -76,6 +106,9 @@ public class WeightedSkewnessUdafTest {
         assertEquals(expectedSkewness, skewness, 0.0001);
     }
 
+    /**
+     * Tests that the {@code merge} method combines two intermediate structs correctly.
+     */
     @Test
     void testMerge() {
         Struct aggOne = new Struct(STRUCT_SCHEMA)
@@ -99,6 +132,9 @@ public class WeightedSkewnessUdafTest {
         assertEquals(760.0, merged.getFloat64(SUM_WEIGHT_CUBES), 0.0001);
     }
 
+    /**
+     * Tests that {@code map} returns 0 when weights are all zero, avoiding division by zero.
+     */
     @Test
     void testMapWithZeroWeights() {
         Struct aggregate = new Struct(STRUCT_SCHEMA)

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/WeightedSkewnessUdafTest.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/WeightedSkewnessUdafTest.java
@@ -54,7 +54,7 @@ public class WeightedSkewnessUdafTest {
      * Tests that the {@code initialize} method creates a struct with all zero fields.
      */
     @Test
-    void testInitialize() {
+    void testInitialize_ShouldContainZeroedState() {
         Struct initialStruct = udafImpl.initialize();
 
         assertNotNull(initialStruct);
@@ -68,7 +68,7 @@ public class WeightedSkewnessUdafTest {
      * Tests that the {@code aggregate} method correctly updates the intermediate aggregation state.
      */
     @Test
-    void testAggregate() {
+    void testAggregate_ShouldUpdateIntermediateStateCorrectly() {
         Pair<Double, Double> pair = new Pair<>(5.0, 2.0);
         Struct aggregateStruct = new Struct(STRUCT_SCHEMA)
                 .put(SUM_VALUES, 10.0)
@@ -89,7 +89,7 @@ public class WeightedSkewnessUdafTest {
      * Tests that the {@code map} method correctly computes the weighted skewness.
      */
     @Test
-    void testMap() {
+    void testMap_ValidRecords_ShouldReturnExpectedSkewness() {
         Struct aggregate = new Struct(STRUCT_SCHEMA)
                 .put(SUM_VALUES, 15.0)
                 .put(SUM_WEIGHTS, 5.0)
@@ -110,7 +110,7 @@ public class WeightedSkewnessUdafTest {
      * Tests that the {@code merge} method combines two intermediate structs correctly.
      */
     @Test
-    void testMerge() {
+    void testMerge_ShouldCombineIntermediateStatesCorrectly() {
         Struct aggOne = new Struct(STRUCT_SCHEMA)
                 .put(SUM_VALUES, 20.0)
                 .put(SUM_WEIGHTS, 6.0)
@@ -136,7 +136,7 @@ public class WeightedSkewnessUdafTest {
      * Tests that {@code map} returns 0 when weights are all zero, avoiding division by zero.
      */
     @Test
-    void testMapWithZeroWeights() {
+    void testMap_ZeroWeights_ShouldReturnZeroSkewness() {
         Struct aggregate = new Struct(STRUCT_SCHEMA)
                 .put(SUM_VALUES, 0.0)
                 .put(SUM_WEIGHTS, 0.0)
@@ -153,7 +153,7 @@ public class WeightedSkewnessUdafTest {
      * even if weights are non-zero (e.g. all values are the same).
      */
     @Test
-    void testMapWithZeroVariance() {
+    void testMap_ZeroVariance_ShouldReturnZeroSkewness() {
         // All values are 3.0, weights are non-zero, so variance = 0
         double repeatedValue = 3.0;
         double totalWeight = 6.0;

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/WeightedStdDevUdafTest.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/WeightedStdDevUdafTest.java
@@ -23,13 +23,13 @@ public class WeightedStdDevUdafTest {
     /** Instance of the UDAF under test. */
     private Udaf<Pair<Double, Double>, Struct, Double> udafImpl;
 
-    /** Field name for the internal aggregation state of the weighted sum. */
+    /** Field name for the internal aggregation state of the sum of values. */
     private static final String SUM_VALUES = "SUM_VALUES";
 
     /** Field name for the internal aggregation state of the sum of weights. */
     private static final String SUM_WEIGHTS = "SUM_WEIGHTS";
 
-    /** Field name for the internal aggregation state of the weighted squares. */
+    /** Field name for the internal aggregation state of the sum of weighted squares. */
     private static final String SUM_WEIGHT_SQUARES = "SUM_WEIGHT_SQUARES";
 
     /** Schema used to structure the aggregation state. */

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/WeightedStdDevUdafTest.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/WeightedStdDevUdafTest.java
@@ -51,7 +51,7 @@ public class WeightedStdDevUdafTest {
      * Tests that the {@code initialize} method returns a struct with zeroed fields.
      */
     @Test
-    void testInitialize() {
+    void testInitialize_ShouldContainZeroedState() {
         Struct initialStruct = udafImpl.initialize();
 
         assertNotNull(initialStruct);
@@ -64,7 +64,7 @@ public class WeightedStdDevUdafTest {
      * Tests that the {@code aggregate} method correctly updates aggregation state for a given input.
      */
     @Test
-    void testAggregate() {
+    void testAggregate_ShouldUpdateIntermediateStateCorrectly() {
         // Create a mock Pair<Double, Double> for value and weight
         Pair<Double, Double> pair = new Pair<>(5.0, 2.0); // value = 5.0, weight = 2.0
         Struct aggregateStruct = new Struct(STRUCT_SCHEMA)
@@ -86,7 +86,7 @@ public class WeightedStdDevUdafTest {
      * Tests that the {@code map} method correctly calculates the weighted standard deviation.
      */
     @Test
-    void testMap() {
+    void testMap_ValidRecords_ShouldReturnExpectedStdDev() {
         // Create a mock Struct with aggregated values
         Struct aggregate = new Struct(STRUCT_SCHEMA)
                 .put(SUM_VALUES, 20.0)
@@ -109,7 +109,7 @@ public class WeightedStdDevUdafTest {
      * Tests that the {@code merge} method correctly combines two intermediate aggregation structs.
      */
     @Test
-    void testMerge() {
+    void testMerge_ShouldCombineIntermediateStatesCorrectly() {
         // Create two mock Struct objects
         Struct aggOne = new Struct(STRUCT_SCHEMA)
                 .put(SUM_VALUES, 10.0)
@@ -135,7 +135,7 @@ public class WeightedStdDevUdafTest {
      * Tests that the {@code map} method returns zero when all weights are zero, avoiding division by zero.
      */
     @Test
-    void testMapWithZeroWeights() {
+    void testMap_ZeroWeights_ShouldReturnZeroStdDev() {
         // Create a mock Struct with zero weights
         Struct aggregate = new Struct(STRUCT_SCHEMA)
                 .put(SUM_VALUES, 0.0)

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/util/UdafMetadata.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/util/UdafMetadata.java
@@ -5,11 +5,23 @@ import org.reflections.Reflections;
 import java.util.Set;
 import java.util.stream.Collectors;
 
+/**
+ * Utility class for retrieving metadata about UDAFs (User-Defined Aggregate Functions)
+ * defined in the project using the {@link UdafDescription} annotation.
+ */
 public class UdafMetadata {
+
+    /**
+     * Scans the project classpath for UDAF classes annotated with {@link UdafDescription}
+     * and collects their declared names in lowercase.
+     *
+     * @return a set of UDAF names registered via {@code @UdafDescription}
+     */
     public static Set<String> getDeclaredUdafNames() {
         Reflections reflections = new Reflections("com.kcharkseliani.kafka.ksql.statistics");
 
         return reflections.getTypesAnnotatedWith(UdafDescription.class).stream()
+                // For each class, retrieve its @UdafDescription annotation instance
                 .map(clazz -> clazz.getAnnotation(UdafDescription.class))
                 .map(desc -> desc.name().toLowerCase())
                 .collect(Collectors.toSet());

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/util/UdafMetadata.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/util/UdafMetadata.java
@@ -1,0 +1,17 @@
+package com.kcharkseliani.kafka.ksql.statistics.util;
+
+import io.confluent.ksql.function.udaf.UdafDescription;
+import org.reflections.Reflections;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+public class UdafMetadata {
+    public static Set<String> getDeclaredUdafNames() {
+        Reflections reflections = new Reflections("com.kcharkseliani.kafka.ksql.statistics");
+
+        return reflections.getTypesAnnotatedWith(UdafDescription.class).stream()
+                .map(clazz -> clazz.getAnnotation(UdafDescription.class))
+                .map(desc -> desc.name().toLowerCase())
+                .collect(Collectors.toSet());
+    }
+}


### PR DESCRIPTION
# 🧪 Add Integration Tests for UDAFs with Testcontainers

This PR introduces full integration tests for verifying custom UDAF behavior (e.g., `STDDEV_WEIGHTED`, `SKEWNESS_WEIGHTED`) in a live ksqlDB environment using **Testcontainers**. It spins up Kafka and ksqlDB containers, mounts the UDAF JAR, and validates correct end-to-end aggregation results through both HTTP queries and Kafka topic assertions.

## 🧩 Key changes

### ✨Enhancements:
- Adds `AllUdafIT` integration test class
- `integrationTest` Gradle task added to run only integration tests
- `verify` Gradle task runs unit tests, builds the JAR, and runs integration tests
- Spins up Kafka and ksqlDB server using Testcontainers
- Mounts the `shadowJar`-built UDAF extension into the ksqlDB container
- Fails the build if Docker is unavailable or tests fail
- Ensures all declared UDAFs via annotation scanning are registered in ksqlDB
- Creates test streams and tables, inserts data, and runs UDAF aggregations
- Verifies output both via pull queries and consuming from Kafka topics
- Enables full testing via `gradle verify` or just integration testing `gradle integrationTest`
- Changed scope of some dependencies which are already provided by ksqlDB to reduce uber-JAR size
- Enabled standard output logging visibility during test runs
- Added Javadoc documentation to all classes

### 🛠 Fixes:
- SKEWNESS_WEIGHTED now handles zero-variance case in the `WeightedSkewnessUdafImpl.map` method and returns zero instead of NaN

### 🔍 Test methods:
#### Unit tests:
- `testMap_ZeroVariance_ShouldReturnZeroSkewness`
🚨 Confirms skewness is 0 when all values are the same (zero variance).
#### Integration tests:
- `testDeployment_ShouldContainAllDeclaredUdafs`
✅ Verifies that all declared UDAFs (annotated with `@UdafDescription`) are registered in ksqlDB.
- `testStddevWeighted_ValidRecordsInserted_ShouldAggregateAll`
📊 Tests STDDEV_WEIGHTED with valid weighted inputs, compares expected vs actual output.
- `testStddevWeighted_AllZeroRecordsInserted_ShouldReturnZero`
🚫 Validates that all-zero weights and values result in a 0 stddev, not NaN or error.
- `testSkewnessWeighted_ValidRecordsInserted_ShouldAggregateAll`
📊 Tests SKEWNESS_WEIGHTED with valid weights and asserts expected skewness.
- `testSkewnessWeighted_AllZeroRecordsInserted_ShouldReturnZero`
🚫 Ensures that all-zero weights and values return 0, not NaN or error.
- `testSkewnessWeighted_ZeroVarianceRecordsInserted_ShouldReturnZero`
🚨 Confirms skewness is 0 when all values are the same (zero variance).

## 📦 Dependencies and Plugins
### ➕ Added:
#### Dependencies:
- `org.testcontainers:kafka:1.19.1` – Kafka Testcontainers module
- `org.testcontainers:junit-jupiter:1.19.1` – JUnit 5 Testcontainers support
- `org.reflections:reflections:0.10.2` – Used to detect UDAFs via annotation scanning
- `org.apache.kafka:kafka-clients:3.3.1` – For consuming results from output topic

### ♻️ Updated:
#### Dependencies:
- `io.confluent.ksql:ksqldb-udf:7.3.1` - scope changed from `implementation` to `compileOnly`
- `org.apache.kafka:kafka_2.13:3.3.1` - scope changed from `implementation` to `compileOnly`

### ❌ Removed:
#### Dependencies:
- ` org.apache.kafka:connect-api:3.3.1` - not required / used

## 📝 Notes
> ⚠️ Docker is required to run these tests. Ensure it is available and running on the host machine.

closes #9 
closes #10
