### PR TITLE
[DEV] Added SPDX-compliant MIT license header to all code files

### DIFF
--- a/src/main/java/com/kcharkseliani/kafka/ksql/statistics/KurtosisUdaf.java
+++ b/src/main/java/com/kcharkseliani/kafka/ksql/statistics/KurtosisUdaf.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.ksql.statistics;
 
 import io.confluent.ksql.function.udaf.Udaf;

--- a/src/main/java/com/kcharkseliani/kafka/ksql/statistics/SkewnessUdaf.java
+++ b/src/main/java/com/kcharkseliani/kafka/ksql/statistics/SkewnessUdaf.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.ksql.statistics;
 
 import io.confluent.ksql.function.udaf.Udaf;

--- a/src/main/java/com/kcharkseliani/kafka/ksql/statistics/WeightedKurtosisUdaf.java
+++ b/src/main/java/com/kcharkseliani/kafka/ksql/statistics/WeightedKurtosisUdaf.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.ksql.statistics;
 
 import io.confluent.ksql.function.udaf.Udaf;

--- a/src/main/java/com/kcharkseliani/kafka/ksql/statistics/WeightedSkewnessUdaf.java
+++ b/src/main/java/com/kcharkseliani/kafka/ksql/statistics/WeightedSkewnessUdaf.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.ksql.statistics;
 
 import io.confluent.ksql.function.udaf.Udaf;

--- a/src/main/java/com/kcharkseliani/kafka/ksql/statistics/WeightedStdDevUdaf.java
+++ b/src/main/java/com/kcharkseliani/kafka/ksql/statistics/WeightedStdDevUdaf.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.ksql.statistics;
 
 import io.confluent.ksql.function.udaf.Udaf;

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/AllUdafIT.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.ksql.statistics;
 
 import com.kcharkseliani.kafka.ksql.statistics.util.UdafMetadata;

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/KurtosisUdafTest.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/KurtosisUdafTest.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.ksql.statistics;
 
 import io.confluent.ksql.function.udaf.Udaf;

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/SkewnessUdafTest.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/SkewnessUdafTest.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.ksql.statistics;
 
 import io.confluent.ksql.function.udaf.Udaf;

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/WeightedKurtosisUdafTest.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/WeightedKurtosisUdafTest.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.ksql.statistics;
 
 import io.confluent.ksql.function.udaf.Udaf;

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/WeightedSkewnessUdafTest.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/WeightedSkewnessUdafTest.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.ksql.statistics;
 
 import io.confluent.ksql.function.udaf.Udaf;

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/WeightedStdDevUdafTest.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/WeightedStdDevUdafTest.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.ksql.statistics;
 
 import io.confluent.ksql.function.udaf.Udaf;

--- a/src/test/java/com/kcharkseliani/kafka/ksql/statistics/util/UdafMetadata.java
+++ b/src/test/java/com/kcharkseliani/kafka/ksql/statistics/util/UdafMetadata.java
@@ -1,3 +1,6 @@
+// SPDX-License-Identifier: MIT
+// Copyright (c) 2025 Konstantin Charkseliani
+
 package com.kcharkseliani.kafka.ksql.statistics.util;
 
 import io.confluent.ksql.function.udaf.UdafDescription;


### PR DESCRIPTION
#  📚 Added SPDX-compliant MIT license header to all code files

This PR added SPDX-License-Identifier and Copyright to all source code files in the repo.

---

## 🧩 Key Changes
### 🗒️Documentation:
- Added `SPDX-License-Identifier: MIT` and `Copyright (c) 2025 Konstantin Charkseliani` to all source code files

---